### PR TITLE
Add include for std::format

### DIFF
--- a/densf.cpp
+++ b/densf.cpp
@@ -8,6 +8,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
+#include <format>
 #include <map>
 
 #define NUM_PIPES 10


### PR DESCRIPTION
This allows densf to be compiled on Ubuntu with `g++ -std=c++20 densf.cpp -o densf`.